### PR TITLE
Bump scala.version from 2.11.11 to 2.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <flink.version>1.9.0</flink.version>
         <alink.scala.major.version>2.11</alink.scala.major.version>
-        <scala.version>2.11.11</scala.version>
+        <scala.version>2.13.1</scala.version>
         <alink.mvn.apache-httpclient.version>4.5.3</alink.mvn.apache-httpclient.version>
         <alink.mvn.gson.version>2.8.2</alink.mvn.gson.version>
         <breeze.version>0.11.2</breeze.version>


### PR DESCRIPTION
Bumps `scala.version` from 2.11.11 to 2.13.1.

Updates `scala-library` from 2.11.11 to 2.13.1
- [Release notes](https://github.com/scala/scala/releases)
- [Commits](https://github.com/scala/scala/compare/v2.11.11...v2.13.1)

Updates `scala-reflect` from 2.11.11 to 2.13.1
- [Release notes](https://github.com/scala/scala/releases)
- [Commits](https://github.com/scala/scala/compare/v2.11.11...v2.13.1)

Updates `scala-compiler` from 2.11.11 to 2.13.1
- [Release notes](https://github.com/scala/scala/releases)
- [Commits](https://github.com/scala/scala/compare/v2.11.11...v2.13.1)

Signed-off-by: dependabot[bot] <support@github.com>